### PR TITLE
Changed some locators

### DIFF
--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -9,7 +9,6 @@ export const config: Config = {
   onPrepare: () => {
     browser.ignoreSynchronization = true;
     reporter();
-    // browser.manage().timeouts().implicitlyWait(3000);
   },
   capabilities: {
     browserName: 'chrome',

--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -9,7 +9,6 @@ export const config: Config = {
   onPrepare: () => {
     browser.ignoreSynchronization = true;
     reporter();
-    // browser.manage().timeouts().implicitlyWait(3000);
   },
   jasmineNodeOpts: {
     defaultTimeoutInterval: 120000

--- a/src/page/address-step.page.ts
+++ b/src/page/address-step.page.ts
@@ -4,7 +4,7 @@ export class AddressStepPage {
   private proceedToCheck: ElementFinder;
 
   constructor () {
-    this.proceedToCheck = $('#center_column > form > p > button > span');
+    this.proceedToCheck = $('[name="processAddress"]');
   }
 
   public async goProceedToCheck(): Promise<void> {

--- a/src/page/bank-payment.page.ts
+++ b/src/page/bank-payment.page.ts
@@ -4,7 +4,7 @@ export class BankPaymentPage {
   private confirmButton: ElementFinder;
 
   constructor () {
-    this.confirmButton = $('#cart_navigation > button > span');
+    this.confirmButton = $('#cart_navigation > button');
   }
 
   public async clickConfirmButton(): Promise<void> {

--- a/src/page/bank-payment.page.ts
+++ b/src/page/bank-payment.page.ts
@@ -1,10 +1,10 @@
-import { $, ElementFinder } from 'protractor';
+import { by, element, ElementFinder } from 'protractor';
 
 export class BankPaymentPage {
   private confirmButton: ElementFinder;
 
   constructor () {
-    this.confirmButton = $('#cart_navigation > button');
+    this.confirmButton = element(by.partialButtonText('I confirm my order'));
   }
 
   public async clickConfirmButton(): Promise<void> {

--- a/src/page/menu-content.page.ts
+++ b/src/page/menu-content.page.ts
@@ -4,7 +4,7 @@ export class MenuContentPage {
   private tShirtMenu: ElementFinder;
 
   constructor () {
-    this.tShirtMenu = $('#block_top_menu > ul > li:nth-child(3) > a');
+    this.tShirtMenu = $('#block_top_menu > ul > li:nth-child(3) > a[title = "T-shirts"]');
   }
 
   public async goToTShirtMenu(): Promise<void> {

--- a/src/page/menu-content.page.ts
+++ b/src/page/menu-content.page.ts
@@ -4,7 +4,7 @@ export class MenuContentPage {
   private tShirtMenu: ElementFinder;
 
   constructor () {
-    this.tShirtMenu = $('#block_top_menu > ul > li:nth-child(3) > a[title = "T-shirts"]');
+    this.tShirtMenu = $('a[title = "T-shirts"]');
   }
 
   public async goToTShirtMenu(): Promise<void> {

--- a/src/page/menu-content.page.ts
+++ b/src/page/menu-content.page.ts
@@ -4,7 +4,7 @@ export class MenuContentPage {
   private tShirtMenu: ElementFinder;
 
   constructor () {
-    this.tShirtMenu = $('a[title = "T-shirts"]');
+    this.tShirtMenu = $('#block_top_menu > ul > li > a[title = "T-shirts"]');
   }
 
   public async goToTShirtMenu(): Promise<void> {

--- a/src/page/payment-step.page.ts
+++ b/src/page/payment-step.page.ts
@@ -5,7 +5,7 @@ export class PaymentStepPage {
   private payBankButton: ElementFinder;
 
   constructor () {
-    this.payBankButton = $('#HOOK_PAYMENT > div:nth-child(1) > div > p > a');
+    this.payBankButton = $('a[title="Pay by bank wire"]');
   }
 
   public async clickPayBankButton(): Promise<void> {

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -5,7 +5,7 @@ export class ProducAddedModalPage{
   private proceedCheckButton: ElementFinder;
 
   constructor() {
-    this.proceedCheckButton = $('[style*="display: block;"] .button-container > a');
+    this.proceedCheckButton = $("a[title='Proceed to checkout']");
   }
 
   public getProceedCheckButton() {

--- a/src/page/product-list.page.ts
+++ b/src/page/product-list.page.ts
@@ -4,7 +4,7 @@ export class ProductListPage {
   private addToCarButton: ElementFinder;
 
   constructor () {
-    this.addToCarButton = $('#center_column a.button.ajax_add_to_cart_button.btn.btn-default');
+    this.addToCarButton = $("a[title='Add to cart']");
   }
 
   public getAddToCarButton() {

--- a/src/page/shipping-step.page.ts
+++ b/src/page/shipping-step.page.ts
@@ -6,7 +6,7 @@ export class ShippingStepPage {
 
   constructor () {
     this.termsOfServiceCheckbox = $('#cgv');
-    this.proceedToCheckButton = $('#form > p > button > span');
+    this.proceedToCheckButton = $('[name="processCarrier"]');
   }
 
   public async acceptTerms (): Promise<void> {

--- a/src/page/sign-in-step.page.ts
+++ b/src/page/sign-in-step.page.ts
@@ -9,7 +9,7 @@ export class SignInStepPage {
   constructor() {
     this.email = $('#email');
     this.password = $('#passwd');
-    this.loginButton = $('#SubmitLogin > span');
+    this.loginButton = $('#SubmitLogin');
   }
 
   public async login(): Promise<void> {


### PR DESCRIPTION
- menu-content.page.ts
1. Before: $('#block_top_menu > ul > li:nth-child(3) > a');
2. After: $('#block_top_menu > ul > li:nth-child(3) > a[title = "T-shirts"]');
I believe the second option is better cause is more specific

- product-list.page.ts
1. Before:  $('#center_column a.button.ajax_add_to_cart_button.btn.btn-default');
2. After: $("a[title='Add to cart']");
Just there is a <a> tag with that title in the whole page. So, I believe is a
good the second option

- product-added-modal.page.ts
1. Before:  $('[style*="display: block;"] .button-container > a');
2. After: $("a[title='Proceed to checkout']");
I think is more readable the second option and shorther than one.

- sign-in-step.page.ts
1. Before: $('#SubmitLogin > span');
2. After: $('#SubmitLogin');
It functions without problem (Y)

- address-step.page.ts
1. Before: $('#center_column > form > p > button > span');
2. After: $('[name]="processAddress"');
There is a only tag with that attribute. So i believe it is a good option.

- shipping-step.page.ts
1. Before: $('#form > p > button > span');
2. After: $('[name="processCarrier"]');
The second option is better than first option. The reason is cause  is more simple
and shorter

- payment-step.page.ts
1. Before: $('#HOOK_PAYMENT > div:nth-child(1) > div > p > a');
2. After: $('a[title="Pay by bank wire"]');
The second option is more readable than first.